### PR TITLE
feat(git): add cleanup alias for merged branches

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -16,6 +16,7 @@
   br = branch
   co = checkout
   sw = switch
+  cleanup = "!git for-each-ref --format '%(refname:short)' --merged=HEAD refs/heads/ | grep -vE '^(main|master|develop)$' | xargs -r git branch -d"
 
 [init]
   defaultBranch = main


### PR DESCRIPTION
## Summary
- Add a `git cleanup` alias that deletes local branches already merged into HEAD, while protecting `main`, `master`, and `develop`.
- Uses `git for-each-ref` instead of parsing `git branch` output to avoid the current-branch (`*`) marker issue.

## Test plan
- [x] Reload gitconfig (re-run bootstrap if symlink not yet in place).
- [x] Run `git cleanup` in a repo with a merged feature branch and confirm only that branch is deleted.
- [x] Confirm `main` / `master` / `develop` are never deleted even when merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)